### PR TITLE
Pull down flow control pin

### DIFF
--- a/components/modbus_spy/__init__.py
+++ b/components/modbus_spy/__init__.py
@@ -1,9 +1,11 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.cpp_helpers import gpio_pin_expression
+from esphome.const import (CONF_ID, CONF_FLOW_CONTROL_PIN)
 from esphome.components import uart
+from esphome import pins
 
-CODEOWNERS = ["@pdjong"]
+CODEOWNERS = ["@electropaultje", "@pdjong"]
 
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["binary_sensor"]
@@ -16,7 +18,8 @@ CONF_LOG_NOT_CONFIGURED_DATA = 'log_not_configured_data'
 
 CONFIG_SCHEMA = cv.Schema({
   cv.GenerateID(): cv.declare_id(ModbusSpy),
-  cv.Optional(CONF_LOG_NOT_CONFIGURED_DATA, default=False): cv.boolean
+  cv.Optional(CONF_LOG_NOT_CONFIGURED_DATA, default=False): cv.boolean,
+  cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema
 }).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 
 async def to_code(config):
@@ -24,3 +27,6 @@ async def to_code(config):
   var = cg.Pvariable(config[CONF_ID], rhs)
   await cg.register_component(var, config)
   await uart.register_uart_device(var, config)
+  if CONF_FLOW_CONTROL_PIN in config:
+    pin = await gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
+    cg.add(var.set_flow_control_pin(pin))

--- a/components/modbus_spy/modbus_spy.cpp
+++ b/components/modbus_spy/modbus_spy.cpp
@@ -1,6 +1,7 @@
 #ifndef UNIT_TEST
 
 #include "esphome/core/log.h"
+#include "esphome/components/esp32/gpio.h"
 
 #include "esp32_arduino_uart_interface.h"
 #include "modbus_binary_sensor.h"
@@ -37,6 +38,13 @@ binary_sensor::BinarySensor* ModbusSpy::create_binary_sensor(
   ModbusBinarySensor *binary_sensor = new ModbusBinarySensor();
   this->data_publisher_.add_binary_sensor(device_address, register_address, bit, binary_sensor);
   return binary_sensor->get_sensor();
+}
+
+void ModbusSpy::set_flow_control_pin(GPIOPin* flow_control_pin) {
+  if (flow_control_pin != nullptr) {
+    flow_control_pin->setup();
+    flow_control_pin->digital_write(false);
+  }
 }
 
 void ModbusSpy::setup() {

--- a/components/modbus_spy/modbus_spy.h
+++ b/components/modbus_spy/modbus_spy.h
@@ -29,7 +29,8 @@ class ModbusSpy : public Component, public uart::UARTDevice {
   uint32_t get_baud_rate() const { return parent_->get_baud_rate(); }
   sensor::Sensor* create_sensor(uint8_t device_address, uint16_t register_address);
   binary_sensor::BinarySensor* create_binary_sensor(uint8_t device_address, uint16_t register_address, int8_t bit);
-
+  void set_flow_control_pin(GPIOPin* flow_control_pin);
+  
  protected:
   ModbusSniffer* sniffer_;
   ModbusDataPublisher data_publisher_;


### PR DESCRIPTION
The new board (v2.2) has the !RX and TX pins connected to GPIO14 instead of directly to ground.
To receive data, the sniffer needs to pull this line low.

This pull request enables configuration of the flow_control_pin on the modbus_spy component. 
If it is configured, the modbus spy will pull it low.

The old boards (pre v2.2) have the !RX and TX (pins 2/3 of the ADM3485EARZ chip) connected to ground.
For those boards the yaml should not configure the flow_control_pin.