### PR TITLE
Use schema functions in sensor configs due to deprecation of SENSOR_SCHEMA / BINARY_SENSOR_SCHEMA

### DIFF
--- a/components/modbus_spy/binary_sensor.py
+++ b/components/modbus_spy/binary_sensor.py
@@ -14,7 +14,7 @@ CONF_DEVICE_ADDRESS = 'device_address'
 CONF_REGISTER_ADDRESS = 'register_address'
 CONF_BIT = 'bit'
 
-CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend({
+CONFIG_SCHEMA = binary_sensor.binary_sensor_schema().extend({
     cv.GenerateID(CONF_MODBUS_SPY_ID): cv.use_id(ModbusSpy),
     cv.Required(CONF_DEVICE_ADDRESS): int,
     cv.Required(CONF_REGISTER_ADDRESS): int,

--- a/components/modbus_spy/sensor.py
+++ b/components/modbus_spy/sensor.py
@@ -13,7 +13,7 @@ CONF_MODBUS_SPY_ID = 'modbus_spy_id'
 CONF_DEVICE_ADDRESS = 'device_address'
 CONF_REGISTER_ADDRESS = 'register_address'
 
-CONFIG_SCHEMA = sensor.SENSOR_SCHEMA.extend({
+CONFIG_SCHEMA = sensor.sensor_schema().extend({
     cv.GenerateID(CONF_MODBUS_SPY_ID): cv.use_id(ModbusSpy),
     cv.Required(CONF_DEVICE_ADDRESS): int,
     cv.Required(CONF_REGISTER_ADDRESS): int


### PR DESCRIPTION
An update in ESPHome requires the Python configuration scripts to use the sensor schema functions (e.g.: `binary_sensor.binary_sensor_schema()` instead of `binary_sensor.BINARY_SENSOR_SCHEMA`).
