### PR TITLE
Enable runtime config of logging data without sensor by providing an Action

### DIFF
--- a/components/modbus_spy/__init__.py
+++ b/components/modbus_spy/__init__.py
@@ -3,7 +3,7 @@ import esphome.config_validation as cv
 from esphome.cpp_helpers import gpio_pin_expression
 from esphome.const import (CONF_ID, CONF_FLOW_CONTROL_PIN)
 from esphome.components import uart
-from esphome import pins
+from esphome import automation, pins
 
 CODEOWNERS = ["@electropaultje", "@pdjong"]
 
@@ -12,8 +12,8 @@ AUTO_LOAD = ["binary_sensor"]
 MULTI_CONF = True
 
 modbus_spy_ns = cg.esphome_ns.namespace('modbus_spy')
-
 ModbusSpy = modbus_spy_ns.class_('ModbusSpy', cg.Component, uart.UARTDevice)
+SetLogUnconfiguredItemsAction = modbus_spy_ns.class_('SetLogUnconfiguredItemsAction', automation.Action)
 CONF_LOG_NOT_CONFIGURED_DATA = 'log_not_configured_data'
 
 CONFIG_SCHEMA = cv.Schema({
@@ -30,3 +30,19 @@ async def to_code(config):
   if CONF_FLOW_CONTROL_PIN in config:
     pin = await gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
     cg.add(var.set_flow_control_pin(pin))
+
+SET_LOG_UNCONFIGURED_ITEMS_ACTION_SCHEMA = cv.maybe_simple_value(
+  {
+    cv.GenerateID(): cv.use_id(ModbusSpy),
+    cv.Required(CONF_LOG_NOT_CONFIGURED_DATA): cv.templatable(cv.boolean)
+  },
+  key=CONF_LOG_NOT_CONFIGURED_DATA
+)
+
+@automation.register_action('modbus_spy.set_log_unconfigured_items', SetLogUnconfiguredItemsAction, SET_LOG_UNCONFIGURED_ITEMS_ACTION_SCHEMA)
+async def set_log_unconfigured_items_to_code(config, action_id, template_arg, args):
+  parent = await cg.get_variable(config[CONF_ID])
+  var = cg.new_Pvariable(action_id, template_arg, parent)
+  templ = await cg.templatable(config[CONF_LOG_NOT_CONFIGURED_DATA], args, cg.bool_)
+  cg.add(var.set_log_unconfigured_items(templ))
+  return var

--- a/components/modbus_spy/automation.h
+++ b/components/modbus_spy/automation.h
@@ -1,0 +1,28 @@
+#ifndef MODBUS_SPY_AUTOMATION_H_
+#define MODBUS_SPY_AUTOMATION_H_
+
+#include "esphome/core/automation.h"
+#include "esphome/core/datatypes.h"
+#include "modbus_spy.h"
+
+namespace esphome {
+namespace modbus_spy {
+
+template<typename... Ts> class SetLogUnconfiguredItemsAction : public Action<Ts...> {
+ public:
+  explicit SetLogUnconfiguredItemsAction(ModbusSpy* modbus_spy) : modbus_spy_(modbus_spy) {}
+  TEMPLATABLE_VALUE(bool, log_unconfigured_items)
+
+  void play(const Ts&... x) override {
+    bool log_unconfigured_items_value = this->log_unconfigured_items_.value(x...);
+    this->modbus_spy_->set_log_unconfigured_items(log_unconfigured_items_value);
+  }
+
+ protected:
+  ModbusSpy* modbus_spy_;
+};
+
+} //namespace modbus_spy
+} //namespace esphome
+
+#endif // MODBUS_SPY_AUTOMATION_H_

--- a/components/modbus_spy/modbus_data_publisher.cpp
+++ b/components/modbus_spy/modbus_data_publisher.cpp
@@ -218,5 +218,9 @@ IModbusBinarySensor** ModbusDataPublisher::find_binary_bit_sensors(uint8_t devic
   return (*device_sensors->binary_sensors_bit_)[data_model_register_address];
 }
 
+void ModbusDataPublisher::set_log_unconfigured_items(bool log_unconfigured_items) {
+  this->should_dump_not_configured_data_ = log_unconfigured_items;
+}
+
 } //namespace modbus_spy
 } //namespace esphome

--- a/components/modbus_spy/modbus_data_publisher.h
+++ b/components/modbus_spy/modbus_data_publisher.h
@@ -45,6 +45,7 @@ class ModbusDataPublisher : public IModbusDataPublisher {
   virtual void add_register_sensor(uint8_t device_address, uint16_t register_address, IModbusRegisterSensor* register_sensor) override;
   virtual void add_binary_sensor(uint8_t device_address, uint16_t register_address, int8_t bit, IModbusBinarySensor* binary_sensor) override;
   virtual void publish_data(uint8_t device_address, uint8_t function, std::vector<ModbusData*>* data) override;
+  void set_log_unconfigured_items(bool log_unconfigured_items);
 
  protected:
   std::map<uint8_t, DeviceSensors*> device_sensors_;

--- a/components/modbus_spy/modbus_spy.cpp
+++ b/components/modbus_spy/modbus_spy.cpp
@@ -47,6 +47,10 @@ void ModbusSpy::set_flow_control_pin(GPIOPin* flow_control_pin) {
   }
 }
 
+void ModbusSpy::set_log_unconfigured_items(bool log_unconfigured_items) {
+    this->data_publisher_.set_log_unconfigured_items(log_unconfigured_items);
+  }
+
 void ModbusSpy::setup() {
   this->sniffer_->start_sniffing();
 }

--- a/components/modbus_spy/modbus_spy.h
+++ b/components/modbus_spy/modbus_spy.h
@@ -30,6 +30,7 @@ class ModbusSpy : public Component, public uart::UARTDevice {
   sensor::Sensor* create_sensor(uint8_t device_address, uint16_t register_address);
   binary_sensor::BinarySensor* create_binary_sensor(uint8_t device_address, uint16_t register_address, int8_t bit);
   void set_flow_control_pin(GPIOPin* flow_control_pin);
+  void set_log_unconfigured_items(bool log_unconfigured_items);
   
  protected:
   ModbusSniffer* sniffer_;


### PR DESCRIPTION
This pull request introduces support for changing the setting to log data for unconfigured sensors in runtime.
It does this by providing an Action named *'modbus_spy.set_log_unconfigured_items'*

It can be used as follows in YAML as an Action:
``` YAML
     - modbus_spy.set_log_unconfigured_items: true
```

or:
``` YAML
     - modbus_spy.set_log_unconfigured_items: 
         id: modbusspy
         log_not_configured_data: false
``` 
Where *modbusspy* is the ID of the modbus_spy component used.