### PR TITLE
Fix crash on non duel core ESP32

### DIFF
--- a/components/modbus_spy/modbus_sniffer.cpp
+++ b/components/modbus_spy/modbus_sniffer.cpp
@@ -36,12 +36,12 @@ ModbusSniffer::~ModbusSniffer() {
 void ModbusSniffer::start_sniffing() {
   ESP_LOGD(TAG, "ModbusSniffer::start_sniffing");
   xTaskCreatePinnedToCore(ModbusSniffer::sniff_loop_task,
-                              "sniff_task", // name
-                              50000,        // stack size (in words)
-                              this,         // input params
-                              1,            // priority
-                              nullptr,      // Handle, not needed
-                              1             // core
+                              "sniff_task",         // name
+                              50000,                // stack size (in words)
+                              this,                 // input params
+                              1,                    // priority
+                              nullptr,              // Handle, not needed
+                              SOC_CPU_CORES_NUM-1   // core
   );
 }
 


### PR DESCRIPTION
not all ESP32 have 2 cores.

ESP32-C3 for example will not boot without this change.

```
[11:29:57.044]assert failed: xTaskCreatePinnedToCore freertos_tasks_c_additions.h:163 (( ( ( ( BaseType_t ) xCoreID ) >= 0 && ( ( BaseType_t ) xCoreID ) < 1 ) ? ( ( BaseType_t ) 1 ) : ( ( BaseType_t ) 0 ) ) == ( (
[11:29:57.044]Core  0 register dump:
[11:29:57.044]MEPC    : 0x403810f8  RA      : 0x4038ae96  SP      : 0x3fca84c0  GP      : 0x3fc94200  
```